### PR TITLE
Changed logging api from slf4j to dynamic logging api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
     <properties>
         <version.java>1.8</version.java>
-        <version.yaslf4j>1.0.0-SNAPSHOT</version.yaslf4j>
+        <version.yaslf4j>1.0.0</version.yaslf4j>
         <version.slf4j>1.7.30</version.slf4j>
         <version.junit>5.8.0-M1</version.junit>
         <version.assertj-core>3.19.0</version.assertj-core>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
 
     <properties>
         <version.java>1.8</version.java>
+        <version.yaslf4j>1.0.0-SNAPSHOT</version.yaslf4j>
         <version.slf4j>1.7.30</version.slf4j>
         <version.junit>5.8.0-M1</version.junit>
         <version.assertj-core>3.19.0</version.assertj-core>
@@ -83,11 +84,10 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${version.slf4j}</version>
+                <groupId>io.github.hakky54</groupId>
+                <artifactId>yaslf4j</artifactId>
+                <version>${version.yaslf4j}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
@@ -116,6 +116,12 @@
                 <groupId>io.github.hakky54</groupId>
                 <artifactId>logcaptor</artifactId>
                 <version>${version.logcaptor}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${version.slf4j}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/sslcontext-kickstart-for-apache4/src/test/java/nl/altindag/ssl/SSLFactoryIT.java
+++ b/sslcontext-kickstart-for-apache4/src/test/java/nl/altindag/ssl/SSLFactoryIT.java
@@ -25,8 +25,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -37,8 +35,6 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Hakan Altindag
  */
 class SSLFactoryIT {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SSLFactoryIT.class);
 
     @Test
     void executeHttpsRequestWithMutualAuthentication() throws IOException {

--- a/sslcontext-kickstart/pom.xml
+++ b/sslcontext-kickstart/pom.xml
@@ -52,8 +52,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>io.github.hakky54</groupId>
+            <artifactId>yaslf4j</artifactId>
         </dependency>
 
         <dependency>

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/SSLFactory.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/SSLFactory.java
@@ -16,6 +16,8 @@
 
 package nl.altindag.ssl;
 
+import nl.altindag.log.Logger;
+import nl.altindag.log.LoggerFactory;
 import nl.altindag.ssl.exception.GenericKeyStoreException;
 import nl.altindag.ssl.exception.GenericSecurityException;
 import nl.altindag.ssl.model.IdentityMaterial;
@@ -31,8 +33,6 @@ import nl.altindag.ssl.util.SSLSocketUtils;
 import nl.altindag.ssl.util.StringUtils;
 import nl.altindag.ssl.util.TrustManagerUtils;
 import nl.altindag.ssl.util.UriUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManagerFactory;

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/keymanager/KeyManagerFactorySpiWrapper.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/keymanager/KeyManagerFactorySpiWrapper.java
@@ -16,8 +16,8 @@
 
 package nl.altindag.ssl.keymanager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import nl.altindag.log.Logger;
+import nl.altindag.log.LoggerFactory;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactorySpi;

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/CompositeX509ExtendedTrustManager.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/CompositeX509ExtendedTrustManager.java
@@ -16,8 +16,8 @@
 
 package nl.altindag.ssl.trustmanager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import nl.altindag.log.Logger;
+import nl.altindag.log.LoggerFactory;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedTrustManager;
@@ -79,54 +79,42 @@ public final class CompositeX509ExtendedTrustManager extends X509ExtendedTrustMa
 
     @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
-        }
+        LOGGER.debug(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
 
         checkTrusted(trustManager -> trustManager.checkClientTrusted(chain, authType));
     }
 
     @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
-        }
+        LOGGER.debug(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
 
         checkTrusted(trustManager -> trustManager.checkClientTrusted(chain, authType, socket));
     }
 
     @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine sslEngine) throws CertificateException {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
-        }
+        LOGGER.debug(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
 
         checkTrusted(trustManager -> trustManager.checkClientTrusted(chain, authType, sslEngine));
     }
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
-        }
+        LOGGER.debug(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
 
         checkTrusted(trustManager -> trustManager.checkServerTrusted(chain, authType));
     }
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
-        }
+        LOGGER.debug(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
 
         checkTrusted(trustManager -> trustManager.checkServerTrusted(chain, authType, socket));
     }
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine sslEngine) throws CertificateException {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
-        }
+        LOGGER.debug(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
 
         checkTrusted(trustManager -> trustManager.checkServerTrusted(chain, authType, sslEngine));
     }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/CompositeX509ExtendedTrustManager.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/CompositeX509ExtendedTrustManager.java
@@ -62,8 +62,8 @@ public final class CompositeX509ExtendedTrustManager extends X509ExtendedTrustMa
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompositeX509ExtendedTrustManager.class);
     private static final String CERTIFICATE_EXCEPTION_MESSAGE = "None of the TrustManagers trust this certificate chain";
-    private static final String CLIENT_CERTIFICATE_LOG_MESSAGE = "Received the following client certificate: [{}]";
-    private static final String SERVER_CERTIFICATE_LOG_MESSAGE = "Received the following server certificate: [{}]";
+    private static final String CLIENT_CERTIFICATE_LOG_MESSAGE = "Received the following client certificate: [%s]";
+    private static final String SERVER_CERTIFICATE_LOG_MESSAGE = "Received the following server certificate: [%s]";
 
     private final List<X509ExtendedTrustManager> trustManagers;
     private final X509Certificate[] acceptedIssuers;
@@ -79,42 +79,42 @@ public final class CompositeX509ExtendedTrustManager extends X509ExtendedTrustMa
 
     @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-        LOGGER.debug(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
+        LOGGER.debug(String.format(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN()));
 
         checkTrusted(trustManager -> trustManager.checkClientTrusted(chain, authType));
     }
 
     @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
-        LOGGER.debug(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
+        LOGGER.debug(String.format(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN()));
 
         checkTrusted(trustManager -> trustManager.checkClientTrusted(chain, authType, socket));
     }
 
     @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine sslEngine) throws CertificateException {
-        LOGGER.debug(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
+        LOGGER.debug(String.format(CLIENT_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN()));
 
         checkTrusted(trustManager -> trustManager.checkClientTrusted(chain, authType, sslEngine));
     }
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-        LOGGER.debug(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
+        LOGGER.debug(String.format(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN()));
 
         checkTrusted(trustManager -> trustManager.checkServerTrusted(chain, authType));
     }
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
-        LOGGER.debug(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
+        LOGGER.debug(String.format(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN()));
 
         checkTrusted(trustManager -> trustManager.checkServerTrusted(chain, authType, socket));
     }
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine sslEngine) throws CertificateException {
-        LOGGER.debug(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN());
+        LOGGER.debug(String.format(SERVER_CERTIFICATE_LOG_MESSAGE, chain[0].getSubjectDN()));
 
         checkTrusted(trustManager -> trustManager.checkServerTrusted(chain, authType, sslEngine));
     }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/TrustManagerFactorySpiWrapper.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/TrustManagerFactorySpiWrapper.java
@@ -16,8 +16,8 @@
 
 package nl.altindag.ssl.trustmanager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import nl.altindag.log.Logger;
+import nl.altindag.log.LoggerFactory;
 
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.TrustManager;

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/UnsafeX509ExtendedTrustManager.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/UnsafeX509ExtendedTrustManager.java
@@ -16,8 +16,8 @@
 
 package nl.altindag.ssl.trustmanager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import nl.altindag.log.Logger;
+import nl.altindag.log.LoggerFactory;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedTrustManager;

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/UnsafeX509ExtendedTrustManager.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/UnsafeX509ExtendedTrustManager.java
@@ -58,7 +58,7 @@ public final class UnsafeX509ExtendedTrustManager extends X509ExtendedTrustManag
 
     private static final String SERVER = "server";
     private static final String CLIENT = "client";
-    private static final String CERTIFICATE_LOG_MESSAGE = "Accepting the following {} certificates without validating: {}";
+    private static final String CERTIFICATE_LOG_MESSAGE = "Accepting the following %s certificates without validating: %s";
     private static final X509Certificate[] EMPTY_CERTIFICATES = new X509Certificate[0];
 
     private UnsafeX509ExtendedTrustManager() {}
@@ -99,7 +99,7 @@ public final class UnsafeX509ExtendedTrustManager extends X509ExtendedTrustManag
 
     private static void logCertificate(X509Certificate[] certificates, String serverOrClient) {
         String principals = extractPrincipals(certificates);
-        LOGGER.warn(CERTIFICATE_LOG_MESSAGE, serverOrClient, principals);
+        LOGGER.warn(String.format(CERTIFICATE_LOG_MESSAGE, serverOrClient, principals));
     }
 
     private static String extractPrincipals(X509Certificate[] certificates) {

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
@@ -16,10 +16,10 @@
 
 package nl.altindag.ssl.util;
 
+import nl.altindag.log.Logger;
+import nl.altindag.log.LoggerFactory;
 import nl.altindag.ssl.exception.GenericKeyStoreException;
 import nl.altindag.ssl.model.KeyStoreHolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.X509TrustManager;
 

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
@@ -173,7 +173,7 @@ public final class KeyStoreUtils {
         }
 
         if (keyStores.isEmpty()) {
-            LOGGER.warn("No system KeyStores available for [{}]", operatingSystem);
+            LOGGER.warn(String.format("No system KeyStores available for [%s]", operatingSystem));
         }
 
         return keyStores;

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/SSLFactoryShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/SSLFactoryShould.java
@@ -931,13 +931,13 @@ class SSLFactoryShould {
 
         int javaMajorVersion = Integer.parseInt(matcher.group(0));
         if (javaMajorVersion < 11) {
-            LOGGER.info("skipping unit test [{}] because TLSv1.3 is not available for this java {} version",
+            LOGGER.info(String.format("skipping unit test [%s] because TLSv1.3 is not available for this java %s version",
                         new Object() {}.getClass().getEnclosingMethod().getName(),
-                        javaVersion);
+                        javaVersion));
             return;
         }
 
-        LOGGER.info("Found java version {}, including testing SSLFactory with TLSv1.3 protocol", javaMajorVersion);
+        LOGGER.info(String.format("Found java version %s, including testing SSLFactory with TLSv1.3 protocol", javaMajorVersion));
         SSLFactory sslFactory = SSLFactory.builder()
                 .withDefaultTrustMaterial()
                 .build();

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/SSLFactoryShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/SSLFactoryShould.java
@@ -17,6 +17,8 @@
 package nl.altindag.ssl;
 
 import nl.altindag.log.LogCaptor;
+import nl.altindag.log.Logger;
+import nl.altindag.log.LoggerFactory;
 import nl.altindag.ssl.exception.GenericKeyManagerException;
 import nl.altindag.ssl.exception.GenericKeyStoreException;
 import nl.altindag.ssl.exception.GenericSecurityException;
@@ -31,8 +33,6 @@ import nl.altindag.ssl.util.TrustManagerUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/CompositeX509ExtendedTrustManagerShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/CompositeX509ExtendedTrustManagerShould.java
@@ -23,17 +23,13 @@ import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.X509ExtendedTrustManager;
-import java.io.IOException;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/HotSwappableX509ExtendedTrustManagerIT.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/HotSwappableX509ExtendedTrustManagerIT.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSessionContext;


### PR DESCRIPTION
This PR ensures that there is no direct dependency to SLF4J logging api. It will take away the need of providing an SLF4J implementation for the end user if they just want to use sslcontext-kickstart without concerning about logging.

Sslcontext kickstart will use [GitHub - YASLF4J](https://github.com/Hakky54/yaslf4j) for logging. Yaslf4j is logging facade api which will delegate the logs to SLF4J if SLF4J is present on the classpath of the enduser, or else it will try Log4j2 or else it will fallback on the default logger which is java util logging logger.

The cons of this solution:
- Additional layer between the logger and the caller

The pros of this solution:
- End user does not need to provide SLF4J binding or Log4j2 binding if they don't care. They also won't be bothered by a warning during runtime when there is no binding available as it will fallback to java util logging