### PR TITLE
Fix parsing PEM on Android v28 and above

### DIFF
--- a/sslcontext-kickstart-for-pem/src/main/java/nl/altindag/ssl/decryptor/PemDecryptor.java
+++ b/sslcontext-kickstart-for-pem/src/main/java/nl/altindag/ssl/decryptor/PemDecryptor.java
@@ -1,6 +1,5 @@
 package nl.altindag.ssl.decryptor;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMDecryptorProvider;
 import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 
@@ -17,8 +16,7 @@ import static nl.altindag.ssl.util.ValidationUtils.requireNotNull;
 public final class PemDecryptor implements BouncyFunction<char[], PEMDecryptorProvider> {
 
     private static final PemDecryptor INSTANCE = new PemDecryptor();
-    private static final JcePEMDecryptorProviderBuilder PEM_DECRYPTOR_PROVIDER_BUILDER = new JcePEMDecryptorProviderBuilder()
-            .setProvider(BouncyCastleProvider.PROVIDER_NAME);
+    private static final JcePEMDecryptorProviderBuilder PEM_DECRYPTOR_PROVIDER_BUILDER = new JcePEMDecryptorProviderBuilder();
 
     private PemDecryptor() {}
 

--- a/sslcontext-kickstart-for-pem/src/main/java/nl/altindag/ssl/decryptor/Pkcs8Decryptor.java
+++ b/sslcontext-kickstart-for-pem/src/main/java/nl/altindag/ssl/decryptor/Pkcs8Decryptor.java
@@ -1,6 +1,5 @@
 package nl.altindag.ssl.decryptor;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder;
 import org.bouncycastle.operator.InputDecryptorProvider;
 import org.bouncycastle.operator.OperatorCreationException;
@@ -18,8 +17,7 @@ import static nl.altindag.ssl.util.ValidationUtils.requireNotNull;
 public final class Pkcs8Decryptor implements BouncyFunction<char[], InputDecryptorProvider> {
 
     private static final Pkcs8Decryptor INSTANCE = new Pkcs8Decryptor();
-    private static final JceOpenSSLPKCS8DecryptorProviderBuilder PKCS8_DECRYPTOR_PROVIDER_BUILDER = new JceOpenSSLPKCS8DecryptorProviderBuilder()
-            .setProvider(BouncyCastleProvider.PROVIDER_NAME);
+    private static final JceOpenSSLPKCS8DecryptorProviderBuilder PKCS8_DECRYPTOR_PROVIDER_BUILDER = new JceOpenSSLPKCS8DecryptorProviderBuilder();
 
     private Pkcs8Decryptor() {}
 

--- a/sslcontext-kickstart-for-pem/src/main/java/nl/altindag/ssl/util/PemUtils.java
+++ b/sslcontext-kickstart-for-pem/src/main/java/nl/altindag/ssl/util/PemUtils.java
@@ -87,8 +87,8 @@ public final class PemUtils {
     private static final char[] DUMMY_PASSWORD = KeyStoreUtils.DUMMY_PASSWORD.toCharArray();
     private static final char[] NO_PASSWORD = null;
 
-    private static final JcaPEMKeyConverter KEY_CONVERTER = new JcaPEMKeyConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME);
-    private static final JcaX509CertificateConverter CERTIFICATE_CONVERTER = new JcaX509CertificateConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME);
+    private static final JcaPEMKeyConverter KEY_CONVERTER = new JcaPEMKeyConverter();
+    private static final JcaX509CertificateConverter CERTIFICATE_CONVERTER = new JcaX509CertificateConverter();
 
     private PemUtils() {}
 


### PR DESCRIPTION
See also: https://android-developers.googleblog.com/2018/03/cryptography-changes-in-android-p.html