### PR TITLE
Extra checks for single trust managers

### DIFF
--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyManagerUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyManagerUtils.java
@@ -255,17 +255,18 @@ public final class KeyManagerUtils {
         requireNotNull(keyManager, GENERIC_EXCEPTION_MESSAGE.apply("KeyManager"));
 
         if (keyManager instanceof CompositeX509ExtendedKeyManager) {
-            return ((CompositeX509ExtendedKeyManager) keyManager)
+            Map<String, List<String>> m = ((CompositeX509ExtendedKeyManager) keyManager)
                     .getIdentityRoute()
                     .entrySet().stream()
-                    .collect(Collectors.collectingAndThen(
+                    .collect(
                             Collectors.toMap(
                                     Entry::getKey,
                                     hosts -> hosts.getValue().stream()
                                             .map(URI::toString)
-                                            .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList))),
-                            Collections::unmodifiableMap)
+                                            .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList)))
+                            
                     );
+            return Collections.unmodifiableMap(m);
         } else {
             throw new GenericKeyManagerException(String.format(
                     "KeyManager should be an instance of: [%s], but received: [%s]",

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/ValidationUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/ValidationUtils.java
@@ -40,6 +40,13 @@ public final class ValidationUtils {
         return maybeNull;
     }
 
+    public static <T> T[] requireNotEmpty(T[] maybeNull, Supplier<RuntimeException> exceptionSupplier) {
+        if (maybeNull == null || maybeNull.length == 0) {
+            throw exceptionSupplier.get();
+        }
+        return maybeNull;
+    }
+    
     public static <T> List<T> requireNotEmpty(List<T> maybeNull, String message) {
         return requireNotEmpty(maybeNull, () -> new IllegalArgumentException(message));
     }


### PR DESCRIPTION
This is pull request for
https://github.com/Hakky54/sslcontext-kickstart/issues/196

I had to do a change which allowed the project to compile in Eclipse
For some reason Eclipse was complaining and could not resolve the type in one of the methods in KeyManagerUtils.

Changes in TrustManagerUtils break some tests.
Some of them are simply extra assertions on logging messages which likely should be removed since for single trust managers there is no wrapping in CompositeX509ExtendedTrustManager
Some failures are more likely related to the fact the tests are expecting it is possible to set up truststore with a trust manager that has no accepted issuers. 
I haven't looked into this

New changes deserve extra tests but it depends if other tests should be change first
Thanks
Daniel