### PR TITLE
Use DefaultClientTlsStrategy with Apache for security purpose

### DIFF
--- a/sslcontext-kickstart-for-apache5/src/main/java/nl/altindag/ssl/apache5/util/Apache5SslUtils.java
+++ b/sslcontext-kickstart-for-apache5/src/main/java/nl/altindag/ssl/apache5/util/Apache5SslUtils.java
@@ -17,9 +17,10 @@ package nl.altindag.ssl.apache5.util;
 
 import nl.altindag.ssl.SSLFactory;
 import org.apache.hc.client5.http.socket.LayeredConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
-import org.apache.hc.core5.http.nio.ssl.BasicClientTlsStrategy;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
 
 /**
  * @author Hakan Altindag
@@ -38,7 +39,13 @@ public final class Apache5SslUtils {
     }
 
     public static TlsStrategy toTlsStrategy(SSLFactory sslFactory) {
-        return new BasicClientTlsStrategy(sslFactory.getSslContext());
+        return new DefaultClientTlsStrategy(
+                sslFactory.getSslContext(),
+                sslFactory.getSslParameters().getProtocols(),
+                sslFactory.getSslParameters().getCipherSuites(),
+                SSLBufferMode.STATIC,
+                sslFactory.getHostnameVerifier()
+        );
     }
 
 }


### PR DESCRIPTION
Hi, thank you for this library.

I have noticed some security concerns regarding the server identity when using Apache Http Client 5 (as needed from the [RFC 2818](https://datatracker.ietf.org/doc/html/rfc2818#section-3.1))

`BasicClientTlsStrategy` doesn't provide any default initializers when creating the `TlsStrategy`, and the SSLContext does not contain some important information, such as the `HostnameVerifier`. As a result, some checks are not done since the verifiers are `null`.

Using `DefaultClientTlsStrategy` will provide a default `HostnameVerifier` needed for the security checks during/after the TLS handshake. Moreover, it allows us to directly pass parameters such as protocols, cipher suites, or hostname verifier (so the specifics parameters from our `SSLFactory` can be applied).

___

Here is a simple code snippet reproducing the issue using[ badssl.com](https://badssl.com/):

```
    var sslFactory = SSLFactory.builder()
      .withDefaultTrustMaterial()
      .build();

    var asyncConnectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
      .setTlsStrategy(Apache5SslUtils.toTlsStrategy(sslFactory))
      //.setTlsStrategy(new DefaultClientTlsStrategy(sslFactory.getSslContext()))
      .build();

    var sharedClient = HttpAsyncClients.custom()
      .setConnectionManager(asyncConnectionManager)
      .build();

    sharedClient.start();

    sharedClient.execute(SimpleRequestBuilder.get("https://wrong.host.badssl.com/").build(), new FutureCallback<>() {
      @Override
      public void completed(SimpleHttpResponse result) {
        System.out.println("completed");
      }

      @Override
      public void failed(Exception ex) {
        System.out.println("failed");
      }

      @Override
      public void cancelled() {
        System.out.println("cancelled");
      }
    }).get();
```

With the current TLS strategy, the get call will be completed successfully, whereas by using `DefaultClientTlsStrategy` you get the following error (which should happen): 
`java.util.concurrent.ExecutionException: javax.net.ssl.SSLPeerUnverifiedException: Certificate for <wrong.host.badssl.com> doesn't match any of the subject alternative names: [*.badssl.com, badssl.com]`
