### PR TITLE
Fix concurrency issue in FenixHostnameVerifier

### DIFF
--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/hostnameverifier/FenixHostnameVerifier.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/hostnameverifier/FenixHostnameVerifier.java
@@ -54,8 +54,6 @@ import static nl.altindag.ssl.hostnameverifier.Hostnames.toCanonicalHost;
 public final class FenixHostnameVerifier implements HostnameVerifier {
 
     private static final HostnameVerifier INSTANCE = new FenixHostnameVerifier();
-    private static final CharsetEncoder ASCII_ENCODER = StandardCharsets.US_ASCII.newEncoder();
-
     private static final int ALT_DNS_NAME = 2;
     private static final int ALT_IPA_NAME = 7;
 
@@ -79,7 +77,7 @@ public final class FenixHostnameVerifier implements HostnameVerifier {
      * Returns true if the [String] is ASCII encoded.
      */
     private boolean isAscii(String value) {
-        return ASCII_ENCODER.canEncode(value);
+        return StandardCharsets.US_ASCII.newEncoder().canEncode(value);
     }
 
     /**

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/hostnameverifier/FenixHostnameVerifier.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/hostnameverifier/FenixHostnameVerifier.java
@@ -54,6 +54,7 @@ import static nl.altindag.ssl.hostnameverifier.Hostnames.toCanonicalHost;
 public final class FenixHostnameVerifier implements HostnameVerifier {
 
     private static final HostnameVerifier INSTANCE = new FenixHostnameVerifier();
+    private static final ThreadLocal<CharsetEncoder> ASCII_ENCODER = ThreadLocal.withInitial(StandardCharsets.US_ASCII::newEncoder);
     private static final int ALT_DNS_NAME = 2;
     private static final int ALT_IPA_NAME = 7;
 
@@ -77,7 +78,7 @@ public final class FenixHostnameVerifier implements HostnameVerifier {
      * Returns true if the [String] is ASCII encoded.
      */
     private boolean isAscii(String value) {
-        return StandardCharsets.US_ASCII.newEncoder().canEncode(value);
+        return ASCII_ENCODER.get().canEncode(value);
     }
 
     /**

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/hostnameverifier/FenixHostnameVerifierShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/hostnameverifier/FenixHostnameVerifierShould.java
@@ -543,6 +543,7 @@ class FenixHostnameVerifierShould {
         IntStream.range(1, cores).forEach(i -> {
             futures.add(executor.submit(() -> hostnameVerifier.verify("���.com", null)));
         });
+        executor.shutdown();
         for (Future<?> future : futures) {
             future.get();
         }

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/hostnameverifier/FenixHostnameVerifierShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/hostnameverifier/FenixHostnameVerifierShould.java
@@ -16,6 +16,11 @@
  */
 package nl.altindag.ssl.hostnameverifier;
 
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
 import nl.altindag.ssl.util.CertificateUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -528,6 +533,19 @@ class FenixHostnameVerifierShould {
         assertThat(HostnameCommon.canParseAsIpAddress("localhost")).isFalse();
         assertThat(HostnameCommon.canParseAsIpAddress("squareup.com")).isFalse();
         assertThat(HostnameCommon.canParseAsIpAddress("www.nintendo.co.jp")).isFalse();
+    }
+
+    @Test
+    void beConcurrentFriendly() throws Exception {
+        int cores = Runtime.getRuntime().availableProcessors();
+        var executor = Executors.newFixedThreadPool(cores);
+        var futures = new ArrayList<Future<?>>();
+        IntStream.range(1, cores).forEach(i -> {
+            futures.add(executor.submit(() -> hostnameVerifier.verify("���.com", null)));
+        });
+        for (Future<?> future : futures) {
+            future.get();
+        }
     }
 
     private SSLSession createSslSession(List<Certificate> certificates) throws SSLPeerUnverifiedException {


### PR DESCRIPTION
As specified in the javadoc, CharsetEncoder is not thread safe.

When multiple threads try to perform requests, I receive:

```
java.lang.IllegalStateException: Current state = CODING_END, new state = CODING
	at java.base/java.nio.charset.CharsetEncoder.throwIllegalStateException(CharsetEncoder.java:996)
	at java.base/java.nio.charset.CharsetEncoder.canEncode(CharsetEncoder.java:908)
	at java.base/java.nio.charset.CharsetEncoder.canEncode(CharsetEncoder.java:989)
	at nl.altindag.ssl.hostnameverifier.FenixHostnameVerifier.isAscii(FenixHostnameVerifier.java:82)
	at nl.altindag.ssl.hostnameverifier.FenixHostnameVerifier.asciiToLowercase(FenixHostnameVerifier.java:203)
	at nl.altindag.ssl.hostnameverifier.FenixHostnameVerifier.verifyHostname(FenixHostnameVerifier.java:162)
	at nl.altindag.ssl.hostnameverifier.FenixHostnameVerifier.lambda$verifyHostname$4(FenixHostnameVerifier.java:142)
	at java.base/java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)
	at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1602)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:632)
	at nl.altindag.ssl.hostnameverifier.FenixHostnameVerifier.verifyHostname(FenixHostnameVerifier.java:142)
	at nl.altindag.ssl.hostnameverifier.FenixHostnameVerifier.verify(FenixHostnameVerifier.java:104)
	at nl.altindag.ssl.hostnameverifier.FenixHostnameVerifier.verify(FenixHostnameVerifier.java:75)
	at org.apache.hc.client5.http.ssl.TlsSessionValidator.verifySession(TlsSessionValidator.java:114)
	at org.apache.hc.client5.http.ssl.AbstractClientTlsStrategy.verifySession(AbstractClientTlsStrategy.java:171)
	at org.apache.hc.client5.http.ssl.AbstractClientTlsStrategy.lambda$upgrade$1(AbstractClientTlsStrategy.java:148)
	at org.apache.hc.core5.reactor.ssl.SSLIOSession.doHandshake(SSLIOSession.java:425)
	at org.apache.hc.core5.reactor.ssl.SSLIOSession.access$100(SSLIOSession.java:74)
	at org.apache.hc.core5.reactor.ssl.SSLIOSession$1.inputReady(SSLIOSession.java:201)
	at org.apache.hc.core5.reactor.InternalDataChannel.onIOEvent(InternalDataChannel.java:142)
	at org.apache.hc.core5.reactor.InternalChannel.handleIOEvent(InternalChannel.java:51)
```