### PR TITLE
Fix trustAnchors parameter must be non empty for InflatableTrustManager

### DIFF
--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/CombinableX509TrustManager.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/CombinableX509TrustManager.java
@@ -43,14 +43,15 @@ interface CombinableX509TrustManager extends X509TrustManager {
             } catch (CertificateException e) {
                 certificateExceptions.add(e);
             } catch (RuntimeException e) {
-                if (e.getCause() instanceof InvalidAlgorithmParameterException) {
+                Throwable cause = e.getCause();
+                if (cause instanceof InvalidAlgorithmParameterException) {
                     // Handling of [InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty]
                     //
                     // This is most likely a result of using a TrustManager created from an empty KeyStore.
                     // The exception will be thrown during the SSL Handshake. It is safe to suppress
                     // and can be bundle with the other exceptions to proceed validating the counterparty with
                     // the remaining TrustManagers.
-                    certificateExceptions.add(new CertificateException(e));
+                    certificateExceptions.add(new CertificateException(cause));
                 } else {
                     throw e;
                 }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/InflatableX509ExtendedTrustManager.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/InflatableX509ExtendedTrustManager.java
@@ -159,6 +159,10 @@ public class InflatableX509ExtendedTrustManager extends HotSwappableX509Extended
         writeLock.lock();
 
         try {
+            if (certificates == null || certificates.isEmpty()) {
+                return;
+            }
+
             for (Certificate certificate : certificates) {
                 String alias = CertificateUtils.generateAlias(certificate);
                 trustStore.setCertificateEntry(alias, certificate);

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/InflatableX509ExtendedTrustManager.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/trustmanager/InflatableX509ExtendedTrustManager.java
@@ -84,7 +84,9 @@ public class InflatableX509ExtendedTrustManager extends HotSwappableX509Extended
             if (trustStorePath != null && StringUtils.isNotBlank(trustStoreType)) {
                 if (Files.exists(trustStorePath)) {
                     trustStore = KeyStoreUtils.loadKeyStore(trustStorePath, trustStorePassword, trustStoreType);
-                    setTrustManager(TrustManagerUtils.createTrustManager(trustStore));
+                    if (KeyStoreUtils.containsTrustMaterial(trustStore)) {
+                        setTrustManager(TrustManagerUtils.createTrustManager(trustStore));
+                    }
                 } else {
                     trustStore = KeyStoreUtils.createKeyStore(trustStoreType, trustStorePassword);
                 }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/TrustManagerUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/TrustManagerUtils.java
@@ -247,6 +247,15 @@ public final class TrustManagerUtils {
      * The provided TrustManager should be an instance of {@link InflatableX509ExtendedTrustManager}
      * and it is allowed that it is wrapped in a {@link CompositeX509ExtendedTrustManager}
      */
+    public static void addCertificate(X509ExtendedTrustManager trustManager, X509Certificate certificate) {
+        addCertificate(trustManager, Collections.singletonList(certificate));
+    }
+
+    /**
+     * Adds a new to be trusted certificate to the existing TrustManager.
+     * The provided TrustManager should be an instance of {@link InflatableX509ExtendedTrustManager}
+     * and it is allowed that it is wrapped in a {@link CompositeX509ExtendedTrustManager}
+     */
     public static void addCertificate(X509ExtendedTrustManager trustManager, List<X509Certificate> certificates) {
         if (trustManager instanceof InflatableX509ExtendedTrustManager) {
             ((InflatableX509ExtendedTrustManager) trustManager).addCertificates(certificates);

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/CompositeX509ExtendedTrustManagerShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/CompositeX509ExtendedTrustManagerShould.java
@@ -26,18 +26,19 @@ import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.X509ExtendedTrustManager;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.Principal;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 /**
  * @author Hakan Altindag
@@ -227,6 +228,30 @@ class CompositeX509ExtendedTrustManagerShould {
         assertThatThrownBy(() -> compositeX509ExtendedTrustManager.checkClientTrusted(trustedCerts, "RSA", SOCKET))
                 .isInstanceOf(CertificateException.class)
                 .hasMessage("None of the TrustManagers trust this certificate chain");
+    }
+
+    @Test
+    void wrapRuntimeExceptionContainingInvalidAlgorithmParameterExceptionIntoSuppressedCertificateException() throws KeyStoreException {
+        KeyStore emptyTrustStore = KeyStoreUtils.createKeyStore();
+        X509ExtendedTrustManager emptyTrustManager = TrustManagerUtils.createTrustManager(emptyTrustStore);
+
+        KeyStore trustStore = KeyStoreUtils.loadKeyStore(KEYSTORE_LOCATION + TRUSTSTORE_FILE_NAME, TRUSTSTORE_PASSWORD);
+        X509Certificate[] certificateChain = KeyStoreTestUtils.getTrustedX509Certificates(trustStore);
+
+        CompositeX509ExtendedTrustManager compositeX509ExtendedTrustManager = new CompositeX509ExtendedTrustManager(Collections.singletonList(emptyTrustManager));
+        assertThat(emptyTrustManager).isNotNull();
+        assertThat(emptyTrustManager.getAcceptedIssuers()).isEmpty();
+        assertThat(certificateChain).hasSize(1);
+        int amountOfTrustManagers = compositeX509ExtendedTrustManager.getInnerTrustManagers().size();
+        assertThat(amountOfTrustManagers).isEqualTo(1);
+
+        CertificateException certificateException = catchThrowableOfType(() -> compositeX509ExtendedTrustManager.checkClientTrusted(certificateChain, "RSA"), CertificateException.class);
+        assertThat(certificateException.getSuppressed()).hasSize(1);
+        Throwable suppressedException = certificateException.getSuppressed()[0];
+
+        assertThat(suppressedException.getCause()).isInstanceOf(RuntimeException.class);
+        assertThat(suppressedException.getCause().getCause()).isInstanceOf(InvalidAlgorithmParameterException.class);
+        assertThat(suppressedException.getCause().getCause().getMessage()).isEqualTo("the trustAnchors parameter must be non-empty");
     }
 
     static class MockedSSLEngine extends SSLEngine {

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/CompositeX509ExtendedTrustManagerShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/CompositeX509ExtendedTrustManagerShould.java
@@ -233,7 +233,7 @@ class CompositeX509ExtendedTrustManagerShould {
     }
 
     @Test
-    void wrapRuntimeExceptionContainingInvalidAlgorithmParameterExceptionIntoSuppressedCertificateException() throws KeyStoreException {
+    void wrapCauseOfRuntimeExceptionContainingInvalidAlgorithmParameterExceptionIntoSuppressedCertificateException() throws KeyStoreException {
         KeyStore emptyTrustStore = KeyStoreUtils.createKeyStore();
         X509ExtendedTrustManager emptyTrustManager = TrustManagerUtils.createTrustManager(emptyTrustStore);
 
@@ -251,9 +251,8 @@ class CompositeX509ExtendedTrustManagerShould {
         assertThat(certificateException.getSuppressed()).hasSize(1);
         Throwable suppressedException = certificateException.getSuppressed()[0];
 
-        assertThat(suppressedException.getCause()).isInstanceOf(RuntimeException.class);
-        assertThat(suppressedException.getCause().getCause()).isInstanceOf(InvalidAlgorithmParameterException.class);
-        assertThat(suppressedException.getCause().getCause().getMessage()).isEqualTo("the trustAnchors parameter must be non-empty");
+        assertThat(suppressedException.getCause()).isInstanceOf(InvalidAlgorithmParameterException.class);
+        assertThat(suppressedException.getCause().getMessage()).isEqualTo("the trustAnchors parameter must be non-empty");
     }
 
     @Test

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/InflatableX509ExtendedTrustManagerShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/InflatableX509ExtendedTrustManagerShould.java
@@ -37,6 +37,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -95,6 +96,34 @@ class InflatableX509ExtendedTrustManagerShould {
 
         assertThat(trustManager.getAcceptedIssuers()).containsExactly(trustedCerts);
         assertThat(logCaptor.getInfoLogs()).containsExactly("Added certificate for [cn=googlecom_o=google-llc_l=mountain-view_st=california_c=us]");
+    }
+
+    @Test
+    void trustManagerWillNotBeReloadedIfNullIsProvidedAsNewCertificate() {
+        LogCaptor logCaptor = LogCaptor.forClass(InflatableX509ExtendedTrustManager.class);
+
+        InflatableX509ExtendedTrustManager trustManager = new InflatableX509ExtendedTrustManager();
+        assertThat(trustManager.getInnerTrustManager()).isInstanceOf(DummyX509ExtendedTrustManager.class);
+
+        trustManager.addCertificates(null);
+        assertThat(trustManager.getInnerTrustManager()).isInstanceOf(DummyX509ExtendedTrustManager.class);
+
+        assertThat(trustManager.getAcceptedIssuers()).isEmpty();
+        assertThat(logCaptor.getLogs()).isEmpty();
+    }
+
+    @Test
+    void trustManagerWillNotBeReloadedIfEmptyListIsProvidedAsNewCertificate() {
+        LogCaptor logCaptor = LogCaptor.forClass(InflatableX509ExtendedTrustManager.class);
+
+        InflatableX509ExtendedTrustManager trustManager = new InflatableX509ExtendedTrustManager();
+        assertThat(trustManager.getInnerTrustManager()).isInstanceOf(DummyX509ExtendedTrustManager.class);
+
+        trustManager.addCertificates(Collections.emptyList());
+        assertThat(trustManager.getInnerTrustManager()).isInstanceOf(DummyX509ExtendedTrustManager.class);
+
+        assertThat(trustManager.getAcceptedIssuers()).isEmpty();
+        assertThat(logCaptor.getLogs()).isEmpty();
     }
 
     @Test

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/InflatableX509ExtendedTrustManagerShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/trustmanager/InflatableX509ExtendedTrustManagerShould.java
@@ -112,6 +112,8 @@ class InflatableX509ExtendedTrustManagerShould {
             Method method = invocationOnMock.getMethod();
             if (method.getName().equals("createKeyStore") && method.getParameters().length == 0) {
                 return mockedTrustStore;
+            } else if (method.getName().equals("containsTrustMaterial") && method.getParameters().length == 1) {
+                return false;
             } else {
                 return invocationOnMock.callRealMethod();
             }

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/util/TrustManagerUtilsShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/util/TrustManagerUtilsShould.java
@@ -531,7 +531,7 @@ class TrustManagerUtilsShould {
     }
 
     @Test
-    void addCertificateToInflatableX509ExtendedTrustManager() {
+    void addCertificatesToInflatableX509ExtendedTrustManager() {
         X509Certificate certificate = mock(X509Certificate.class);
         List<X509Certificate> certificates = Collections.singletonList(certificate);
 
@@ -539,6 +539,16 @@ class TrustManagerUtilsShould {
         TrustManagerUtils.addCertificate(trustManager, certificates);
 
         verify(trustManager, times(1)).addCertificates(certificates);
+    }
+
+    @Test
+    void addCertificateToInflatableX509ExtendedTrustManager() {
+        X509Certificate certificate = mock(X509Certificate.class);
+
+        InflatableX509ExtendedTrustManager trustManager = mock(InflatableX509ExtendedTrustManager.class);
+        TrustManagerUtils.addCertificate(trustManager, certificate);
+
+        verify(trustManager, times(1)).addCertificates(Collections.singletonList(certificate));
     }
 
     @Test


### PR DESCRIPTION
This issue is related to a change in an earlier PR, see here: https://github.com/Hakky54/sslcontext-kickstart/pull/338/files#diff-c809d1f6e457e2f23989aba7049668291aa8d4ab8ea467cacb8b1c694f326c44L448

A TrustManager which does not contain a trusted certificate was earlier filtered out, but recently dropped to allow custom TrustManagers such as InflatableTrustManager which can have no trusted certficates during the initial creation.

The adjustment in the TrustManagerUtils also resulted into allowing to  combine an empty trustmanager with other trustmanagers into a composite trustmanager, however it would not proceed the validation with other trustmanagers because of the InvalidAlgorithmParameterException which was thrown because one of the emtpy trustmanager.

An emtpy trustmanager is allowed in the composite trust manager, however the flow needs to proceed as other trust manager might trust the counter party. Therefor the InvalidAlgorithmParameterException will be catched and suppressed. If the other trustmanagers also don't trust the counter party a CertificateException will be thrown having the messsage: `None of the TrustManagers trust this certificate chain` which should be explaining enough.