### PR TITLE
Added option to reload the ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,16 @@ In that way existing connections which already have done the ssl handshake won't
 ```text
 SSLFactoryUtils.reload(baseSslFactory, updatedSslFactory, false);
 ```
+Additionally the SSL parameters can also be reloaded such as ciphers. A basic example is demonstrated below:
+```text
+SSLFactory sslFactory = SSLFactory.builder()
+          .withIdentityMaterial(Paths.get("/path/to/your/identity.jks"), "password".toCharArray())
+          .withTrustMaterial(Paths.get("/path/to/your/truststore.jks"), "password".toCharArray())
+          .withSwappableSslParameters
+          .build();
+          
+sslFactory.getSslParameters().setCipherSuites(new String[]{"TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"})
+```
 
 ##### Support for swapping KeyManager and TrustManager at runtime
 It is possible to swap a KeyManager and TrustManager from a SSLContext, SSLSocketFactory and SSLServerSocketFactory while already using it within your client or server at runtime. This option will enable to refresh the identity and trust material of a server or client without the need of restarting your application or recreating it with SSLFactory. The identity and trust material may expire at some point in time and needs to be replaced to be still functional.

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/SSLFactory.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/SSLFactory.java
@@ -884,8 +884,6 @@ public final class SSLFactory {
                     .withTrustManager(trustManager)
                     .withSslParameters(baseSslParameters)
                     .withHostnameVerifier(resolvedHostnameVerifier)
-                    .withCiphers(Collections.unmodifiableList(Arrays.asList(baseSslParameters.getCipherSuites())))
-                    .withProtocols(Collections.unmodifiableList(Arrays.asList(baseSslParameters.getProtocols())))
                     .build();
 
             return new SSLFactory(sslMaterial);

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/SSLFactory.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/SSLFactory.java
@@ -193,6 +193,7 @@ public final class SSLFactory {
 
         private boolean swappableKeyManagerEnabled = false;
         private boolean swappableTrustManagerEnabled = false;
+        private boolean swappableSslParametersEnabled = false;
         private boolean loggingKeyManagerEnabled = false;
         private boolean loggingTrustManagerEnabled = false;
 
@@ -756,6 +757,11 @@ public final class SSLFactory {
             return this;
         }
 
+        public Builder withSwappableSslParameters() {
+            swappableSslParametersEnabled = true;
+            return this;
+        }
+
         public <T extends Provider> Builder withSecurityProvider(T securityProvider) {
             this.securityProvider = securityProvider;
             return this;
@@ -939,7 +945,8 @@ public final class SSLFactory {
             sslParameters.setCipherSuites(preferredCiphers);
             sslParameters.setProtocols(preferredProtocols);
 
-            return SSLParametersUtils.merge(sslParameters, defaultSSLParameters, excludedCiphers, excludedProtocols);
+            SSLParameters mergedSslParameters = SSLParametersUtils.merge(sslParameters, defaultSSLParameters, excludedCiphers, excludedProtocols);
+            return swappableSslParametersEnabled ? SSLParametersUtils.createSwappableSslParameters(mergedSslParameters) : mergedSslParameters;
         }
 
     }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/model/internal/SSLMaterial.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/model/internal/SSLMaterial.java
@@ -20,6 +20,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509ExtendedTrustManager;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -37,8 +38,6 @@ public final class SSLMaterial {
     private X509ExtendedTrustManager trustManager;
     private HostnameVerifier hostnameVerifier;
     private SSLParameters sslParameters;
-    private List<String> ciphers;
-    private List<String> protocols;
 
     private SSLMaterial() {}
 
@@ -63,11 +62,11 @@ public final class SSLMaterial {
     }
 
     public List<String> getCiphers() {
-        return ciphers;
+        return Arrays.asList(sslParameters.getCipherSuites());
     }
 
     public List<String> getProtocols() {
-        return protocols;
+        return Arrays.asList(sslParameters.getProtocols());
     }
 
     public static class Builder {
@@ -77,8 +76,6 @@ public final class SSLMaterial {
         private X509ExtendedTrustManager trustManager;
         private HostnameVerifier hostnameVerifier;
         private SSLParameters sslParameters;
-        private List<String> ciphers;
-        private List<String> protocols;
 
         public Builder withSslContext(SSLContext sslContext) {
             this.sslContext = sslContext;
@@ -92,16 +89,6 @@ public final class SSLMaterial {
 
         public Builder withSslParameters(SSLParameters sslParameters) {
             this.sslParameters = sslParameters;
-            return this;
-        }
-
-        public Builder withCiphers(List<String> ciphers) {
-            this.ciphers = ciphers;
-            return this;
-        }
-
-        public Builder withProtocols(List<String> protocols) {
-            this.protocols = protocols;
             return this;
         }
 
@@ -122,8 +109,6 @@ public final class SSLMaterial {
             sslMaterial.trustManager = trustManager;
             sslMaterial.hostnameVerifier = hostnameVerifier;
             sslMaterial.sslParameters = sslParameters;
-            sslMaterial.ciphers = ciphers;
-            sslMaterial.protocols = protocols;
             return sslMaterial;
         }
     }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/sslparameters/DelegatingSSLParameters.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/sslparameters/DelegatingSSLParameters.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 Thunderberry.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.altindag.ssl.sslparameters;
+
+import javax.net.ssl.SSLParameters;
+import java.security.AlgorithmConstraints;
+
+public class DelegatingSSLParameters extends SSLParameters {
+
+    SSLParameters sslParameters;
+
+    public DelegatingSSLParameters(SSLParameters sslParameters) {
+        this.sslParameters = sslParameters;
+    }
+
+    public SSLParameters getInnerSslParameters() {
+        return sslParameters;
+    }
+
+    @Override
+    public String[] getCipherSuites() {
+        return sslParameters.getCipherSuites();
+    }
+
+    @Override
+    public String[] getProtocols() {
+        return sslParameters.getProtocols();
+    }
+
+    @Override
+    public boolean getWantClientAuth() {
+        return sslParameters.getWantClientAuth();
+    }
+
+    @Override
+    public boolean getNeedClientAuth() {
+        return sslParameters.getNeedClientAuth();
+    }
+
+    @Override
+    public AlgorithmConstraints getAlgorithmConstraints() {
+        return sslParameters.getAlgorithmConstraints();
+    }
+
+    @Override
+    public String getEndpointIdentificationAlgorithm() {
+        return sslParameters.getEndpointIdentificationAlgorithm();
+    }
+
+    @Override
+    public void setCipherSuites(String[] cipherSuites) {
+        sslParameters.setCipherSuites(cipherSuites);
+    }
+
+    @Override
+    public void setProtocols(String[] protocols) {
+        sslParameters.setProtocols(protocols);
+    }
+
+    @Override
+    public void setWantClientAuth(boolean wantClientAuth) {
+        sslParameters.setWantClientAuth(wantClientAuth);
+    }
+
+    @Override
+    public void setNeedClientAuth(boolean needClientAuth) {
+        sslParameters.setNeedClientAuth(needClientAuth);
+    }
+
+    @Override
+    public void setAlgorithmConstraints(AlgorithmConstraints constraints) {
+        sslParameters.setAlgorithmConstraints(constraints);
+    }
+
+    @Override
+    public void setEndpointIdentificationAlgorithm(String algorithm) {
+        sslParameters.setEndpointIdentificationAlgorithm(algorithm);
+    }
+
+    public void setSslParameters(SSLParameters sslParameters) {
+        this.sslParameters = sslParameters;
+    }
+
+}

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/sslparameters/HotSwappableSSLParameters.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/sslparameters/HotSwappableSSLParameters.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Thunderberry.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.altindag.ssl.sslparameters;
+
+import javax.net.ssl.SSLParameters;
+import java.security.AlgorithmConstraints;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static nl.altindag.ssl.util.internal.ValidationUtils.GENERIC_EXCEPTION_MESSAGE;
+import static nl.altindag.ssl.util.internal.ValidationUtils.requireNotNull;
+
+public final class HotSwappableSSLParameters extends DelegatingSSLParameters {
+
+    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    private final Lock readLock = readWriteLock.readLock();
+    private final Lock writeLock = readWriteLock.writeLock();
+
+    public HotSwappableSSLParameters(SSLParameters sslParameters) {
+        super(sslParameters);
+    }
+
+    public void setSslParameters(SSLParameters sslParameters) {
+        setSafely(() -> super.setSslParameters(requireNotNull(sslParameters, GENERIC_EXCEPTION_MESSAGE.apply("SSLParameters"))));
+    }
+
+    @Override
+    public SSLParameters getInnerSslParameters() {
+        return getSafely(super::getInnerSslParameters);
+    }
+
+    @Override
+    public String[] getCipherSuites() {
+        return getSafely(super::getCipherSuites);
+    }
+
+    @Override
+    public String[] getProtocols() {
+        return getSafely(super::getProtocols);
+    }
+
+    @Override
+    public boolean getWantClientAuth() {
+        return getSafely(super::getWantClientAuth);
+    }
+
+    @Override
+    public boolean getNeedClientAuth() {
+        return getSafely(super::getNeedClientAuth);
+    }
+
+    @Override
+    public AlgorithmConstraints getAlgorithmConstraints() {
+        return getSafely(super::getAlgorithmConstraints);
+    }
+
+    @Override
+    public String getEndpointIdentificationAlgorithm() {
+        return getSafely(super::getEndpointIdentificationAlgorithm);
+    }
+
+    @Override
+    public void setCipherSuites(String[] cipherSuites) {
+        setSafely(() -> super.setCipherSuites(cipherSuites));
+    }
+
+    @Override
+    public void setProtocols(String[] protocols) {
+        setSafely(() -> super.setProtocols(protocols));
+    }
+
+    @Override
+    public void setWantClientAuth(boolean wantClientAuth) {
+        setSafely(() -> super.setWantClientAuth(wantClientAuth));
+    }
+
+    @Override
+    public void setNeedClientAuth(boolean needClientAuth) {
+        setSafely(() -> super.setNeedClientAuth(needClientAuth));
+    }
+
+    @Override
+    public void setAlgorithmConstraints(AlgorithmConstraints constraints) {
+        setSafely(() -> super.setAlgorithmConstraints(constraints));
+    }
+
+    @Override
+    public void setEndpointIdentificationAlgorithm(String algorithm) {
+        setSafely(() -> super.setEndpointIdentificationAlgorithm(algorithm));
+    }
+
+    private <V> V getSafely(SSLParametersCallable<V> sslParametersCallable) {
+        readLock.lock();
+        try {
+            return sslParametersCallable.call();
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    private void setSafely(SSLParametersRunnable sslParametersRunnable) {
+        writeLock.lock();
+
+        try {
+            sslParametersRunnable.run();
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+}

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/sslparameters/HotSwappableSSLParameters.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/sslparameters/HotSwappableSSLParameters.java
@@ -34,6 +34,7 @@ public final class HotSwappableSSLParameters extends DelegatingSSLParameters {
         super(sslParameters);
     }
 
+    @Override
     public void setSslParameters(SSLParameters sslParameters) {
         setSafely(() -> super.setSslParameters(requireNotNull(sslParameters, GENERIC_EXCEPTION_MESSAGE.apply("SSLParameters"))));
     }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/sslparameters/SSLParametersCallable.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/sslparameters/SSLParametersCallable.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Thunderberry.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.altindag.ssl.sslparameters;
+
+/**
+ * <strong>NOTE:</strong>
+ * Please don't use this class directly as it is part of the internal API. Class name and methods can be changed any time.
+ *
+ * @author Hakan Altindag
+ */
+@FunctionalInterface
+interface SSLParametersCallable<V> {
+
+    V call();
+
+}

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/sslparameters/SSLParametersRunnable.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/sslparameters/SSLParametersRunnable.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Thunderberry.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.altindag.ssl.sslparameters;
+
+/**
+ * <strong>NOTE:</strong>
+ * Please don't use this class directly as it is part of the internal API. Class name and methods can be changed any time.
+ *
+ * @author Hakan Altindag
+ */
+@FunctionalInterface
+interface SSLParametersRunnable {
+
+    void run();
+
+}

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/SSLFactoryUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/SSLFactoryUtils.java
@@ -16,10 +16,14 @@
 package nl.altindag.ssl.util;
 
 import nl.altindag.ssl.SSLFactory;
+import nl.altindag.ssl.keymanager.HotSwappableX509ExtendedKeyManager;
+import nl.altindag.ssl.sslparameters.HotSwappableSSLParameters;
+import nl.altindag.ssl.trustmanager.HotSwappableX509ExtendedTrustManager;
 
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * @author Hakan Altindag
@@ -41,8 +45,10 @@ public final class SSLFactoryUtils {
      * Other properties such as ciphers, protocols, secure-random, {@link javax.net.ssl.HostnameVerifier} and {@link javax.net.ssl.SSLParameters} will not be reloaded.
      */
     public static void reload(SSLFactory baseSslFactory, SSLFactory updatedSslFactory, boolean shouldInvalidateCaches) {
-        reload(baseSslFactory, updatedSslFactory, SSLFactory::getKeyManager, KeyManagerUtils::swapKeyManager);
-        reload(baseSslFactory, updatedSslFactory, SSLFactory::getTrustManager, TrustManagerUtils::swapTrustManager);
+        reload(baseSslFactory, updatedSslFactory, SSLFactory::getKeyManager, HotSwappableX509ExtendedKeyManager.class::isInstance, KeyManagerUtils::swapKeyManager);
+        reload(baseSslFactory, updatedSslFactory, SSLFactory::getTrustManager, HotSwappableX509ExtendedTrustManager.class::isInstance, TrustManagerUtils::swapTrustManager);
+        reload(baseSslFactory, updatedSslFactory, sslFactory -> Optional.of(sslFactory.getSslParameters()), HotSwappableSSLParameters.class::isInstance, SSLParametersUtils::swapSslParameters);
+
         if (shouldInvalidateCaches) {
             SSLSessionUtils.invalidateCaches(baseSslFactory);
         }
@@ -51,12 +57,13 @@ public final class SSLFactoryUtils {
     private static <T> void reload(SSLFactory baseSslFactory,
                                    SSLFactory updatedSslFactory,
                                    Function<SSLFactory, Optional<T>> mapper,
+                                   Predicate<T> predicate,
                                    BiConsumer<T, T> consumer) {
 
-        Optional<T> baseManager = mapper.apply(baseSslFactory);
-        Optional<T> updatedManager = mapper.apply(updatedSslFactory);
-        if (baseManager.isPresent() && updatedManager.isPresent()) {
-            consumer.accept(baseManager.get(), updatedManager.get());
+        Optional<T> base = mapper.apply(baseSslFactory).filter(predicate);
+        Optional<T> update = mapper.apply(updatedSslFactory);
+        if (base.isPresent() && update.isPresent()) {
+            consumer.accept(base.get(), update.get());
         }
     }
 

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/SSLParametersUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/SSLParametersUtils.java
@@ -15,7 +15,6 @@
  */
 package nl.altindag.ssl.util;
 
-import nl.altindag.ssl.exception.GenericTrustManagerException;
 import nl.altindag.ssl.sslparameters.HotSwappableSSLParameters;
 
 import javax.net.ssl.SSLParameters;
@@ -113,32 +112,6 @@ public final class SSLParametersUtils {
      */
     public static SSLParameters createSwappableSslParameters(SSLParameters sslParameters) {
         return new HotSwappableSSLParameters(sslParameters);
-    }
-
-    public static void swapCiphers(SSLParameters baseSslParameters, List<String> ciphers) {
-        SSLParameters newSslParameters = new SSLParameters(ciphers.toArray(new String[]{}));
-        swapSslParameters(baseSslParameters, newSslParameters);
-    }
-
-    public static void swapSslParameters(SSLParameters baseSslParameters, SSLParameters newSslParameters) {
-        if (!(baseSslParameters instanceof HotSwappableSSLParameters)) {
-            throw new GenericTrustManagerException(
-                    String.format("The baseSslParameters is from the instance of [%s] and should be an instance of [%s].",
-                            baseSslParameters.getClass().getName(),
-                            HotSwappableSSLParameters.class.getName())
-            );
-        }
-
-        if (newSslParameters instanceof HotSwappableSSLParameters) {
-            throw new GenericTrustManagerException(
-                    String.format("The newSslParameters should not be an instance of [%s]", HotSwappableSSLParameters.class.getName())
-            );
-        }
-
-        HotSwappableSSLParameters swappableSslParameters = (HotSwappableSSLParameters) baseSslParameters;
-
-        // Initially only support setting ciphers
-        swappableSslParameters.setCipherSuites(newSslParameters.getCipherSuites());
     }
 
 }

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/SSLFactoryIT.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/SSLFactoryIT.java
@@ -407,7 +407,7 @@ class SSLFactoryIT {
         assertThat(response.getStatusCode()).isEqualTo(200);
         assertThat(response.getBody()).contains("Hello from server one");
 
-        sslFactoryForClient.getSslParameters().setCipherSuites(new String[]{"TLS_AES_256_GCM_SHA384"});
+        sslFactoryForClient.getSslParameters().setCipherSuites(new String[]{"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"});
 
         assertThatThrownBy(() -> executeRequest("https://localhost:8443/api/hello", sslSocketFactory))
                 .isInstanceOfAny(SocketException.class, SSLException.class);

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/SSLFactoryIT.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/SSLFactoryIT.java
@@ -382,6 +382,39 @@ class SSLFactoryIT {
         server.stop();
     }
 
+    @Test
+    void executeRequestToServerWithMutualAuthenticationWithSwappingCiphers() throws IOException {
+        char[] keyStorePassword = "secret".toCharArray();
+
+        SSLFactory sslFactoryForServer = SSLFactory.builder()
+                .withIdentityMaterial("keystore/client-server/server-one/identity.jks", keyStorePassword)
+                .withTrustMaterial("keystore/client-server/server-one/truststore.jks", keyStorePassword)
+                .withNeedClientAuthentication()
+                .withProtocols("TLSv1.2")
+                .build();
+
+        Server server = Server.createDefault(sslFactoryForServer, 8443, "Hello from server one");
+
+        SSLFactory sslFactoryForClient = SSLFactory.builder()
+                .withIdentityMaterial("keystore/client-server/client-one/identity.jks", keyStorePassword)
+                .withTrustMaterial("keystore/client-server/client-one/truststore.jks", keyStorePassword)
+                .withSwappableSslParameters()
+                .build();
+
+        SSLSocketFactory sslSocketFactory = sslFactoryForClient.getSslSocketFactory();
+
+        Response response = executeRequest("https://localhost:8443/api/hello", sslSocketFactory);
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getBody()).contains("Hello from server one");
+
+        sslFactoryForClient.getSslParameters().setCipherSuites(new String[]{"TLS_AES_256_GCM_SHA384"});
+
+        assertThatThrownBy(() -> executeRequest("https://localhost:8443/api/hello", sslSocketFactory))
+                .isInstanceOfAny(SocketException.class, SSLException.class);
+
+        server.stop();
+    }
+
     private Response executeRequest(String url, SSLSocketFactory sslSocketFactory) throws IOException {
         HttpsURLConnection connection = (HttpsURLConnection) new URL(url).openConnection();
         connection.setSSLSocketFactory(sslSocketFactory);

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/sslparameters/HowSwappableSslParametersShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/sslparameters/HowSwappableSslParametersShould.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019 Thunderberry.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.altindag.ssl.sslparameters;
+
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLParameters;
+
+import java.security.AlgorithmConstraints;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Hakan Altindag
+ */
+class HowSwappableSslParametersShould {
+
+    @Test
+    void setSslParameters() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        SSLParameters newInnerSslParameters = mock(SSLParameters.class);
+
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+        assertThat(swappableSSLParameters.getInnerSslParameters()).isEqualTo(innerSslParameters);
+
+        swappableSSLParameters.setSslParameters(newInnerSslParameters);
+        assertThat(swappableSSLParameters.getInnerSslParameters())
+                .isNotEqualTo(innerSslParameters)
+                .isEqualTo(newInnerSslParameters);
+    }
+
+    @Test
+    void getInnerSslParameters() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        assertThat(swappableSSLParameters.getInnerSslParameters()).isEqualTo(innerSslParameters);
+    }
+
+    @Test
+    void getCipherSuites() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.getCipherSuites();
+        verify(innerSslParameters, times(1)).getCipherSuites();
+    }
+
+    @Test
+    void getProtocols() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.getProtocols();
+        verify(innerSslParameters, times(1)).getProtocols();
+    }
+
+    @Test
+    void getWantClientAuth() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.getWantClientAuth();
+        verify(innerSslParameters, times(1)).getWantClientAuth();
+    }
+
+    @Test
+    void getNeedClientAuth() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.getNeedClientAuth();
+        verify(innerSslParameters, times(1)).getNeedClientAuth();
+    }
+
+    @Test
+    void getAlgorithmConstraints() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.getAlgorithmConstraints();
+        verify(innerSslParameters, times(1)).getAlgorithmConstraints();
+    }
+
+    @Test
+    void getEndpointIdentificationAlgorithm() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.getEndpointIdentificationAlgorithm();
+        verify(innerSslParameters, times(1)).getEndpointIdentificationAlgorithm();
+    }
+
+    @Test
+    void setCipherSuites() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.setCipherSuites(new String[]{"some-cipher"});
+        verify(innerSslParameters, times(1)).setCipherSuites(any());
+    }
+
+    @Test
+    void setProtocols() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.setProtocols(new String[]{"some-protocol"});
+        verify(innerSslParameters, times(1)).setProtocols(any());
+    }
+
+    @Test
+    void setWantClientAuth() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.setWantClientAuth(true);
+        verify(innerSslParameters, times(1)).setWantClientAuth(true);
+    }
+
+    @Test
+    void setNeedClientAuth() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.setNeedClientAuth(true);
+        verify(innerSslParameters, times(1)).setNeedClientAuth(true);
+    }
+
+    @Test
+    void setAlgorithmConstraints() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.setAlgorithmConstraints(mock(AlgorithmConstraints.class));
+        verify(innerSslParameters, times(1)).setAlgorithmConstraints(any());
+    }
+
+    @Test
+    void setEndpointIdentificationAlgorithm() {
+        SSLParameters innerSslParameters = mock(SSLParameters.class);
+        HotSwappableSSLParameters swappableSSLParameters = new HotSwappableSSLParameters(innerSslParameters);
+
+        swappableSSLParameters.setEndpointIdentificationAlgorithm("some-algorithm");
+        verify(innerSslParameters, times(1)).setEndpointIdentificationAlgorithm(anyString());
+    }
+
+}


### PR DESCRIPTION
There is need for adjusting the ciphers at runtime. Below is the usage based on the code adjustments of the PR.

```java
import javax.net.ssl.SSLParameters;

public class App {

    public static void main(String[] args) {
        SSLFactory sslFactory = SSLFactory.builder()
                .withDefaultTrustMaterial()
                .withSwappableSslParameters()
                .build();

        SSLParameters sslParameters = sslFactory.getSslParameters();
        sslParameters.setCipherSuites(new String[]{"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"});
        SSLSessionUtils.invalidateCaches(sslFactory);
    }

}
```

By default sslfactory provides inmutable sslparameter, however when adding the option `withSwappableSslParameters` with will wrap the actual sslparameters in a custom one which is able to set the different properties in a thread safe mechanism. This makes it also possible adjust other properties of the sslparameters such as protocols.