### PR TITLE
Loading Windows keystores with a timeout option

### DIFF
--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
@@ -17,7 +17,7 @@ package nl.altindag.ssl.util;
 
 import nl.altindag.ssl.exception.GenericKeyStoreException;
 import nl.altindag.ssl.util.internal.CollectorsUtils;
-import nl.altindag.ssl.util.internal.ConcurrentUtils;
+import nl.altindag.ssl.util.internal.ConcurrencyUtils;
 import nl.altindag.ssl.util.internal.IOUtils;
 import nl.altindag.ssl.util.internal.StringUtils;
 import org.slf4j.Logger;
@@ -262,7 +262,7 @@ public final class KeyStoreUtils {
         try {
             KeyStore keyStore;
             if (OperatingSystem.get() == WINDOWS) {
-                keyStore = ConcurrentUtils.supplyAsync(() -> createKeyStore(keyStoreType, keyStorePassword)).get(500, TimeUnit.MILLISECONDS);
+                keyStore = ConcurrencyUtils.supplyAsync(() -> createKeyStore(keyStoreType, keyStorePassword)).get(500, TimeUnit.MILLISECONDS);
             } else {
                 keyStore = createKeyStore(keyStoreType, keyStorePassword);
             }
@@ -273,6 +273,10 @@ public final class KeyStoreUtils {
             }
             return Optional.of(keyStore);
         } catch (Exception exception) {
+            if (exception instanceof InterruptedException) {
+                LOGGER.debug("Thread has been interrupted", exception);
+                Thread.currentThread().interrupt();
+            }
             LOGGER.debug(String.format("Failed to load KeyStore of the type [%s]", keyStoreType), exception);
             return Optional.empty();
         }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
@@ -262,7 +262,7 @@ public final class KeyStoreUtils {
         try {
             KeyStore keyStore;
             if (OperatingSystem.get() == WINDOWS) {
-                keyStore = ConcurrentUtils.supplyAsync(() -> createKeyStore(keyStoreType, keyStorePassword)).get(250, TimeUnit.MILLISECONDS);
+                keyStore = ConcurrentUtils.supplyAsync(() -> createKeyStore(keyStoreType, keyStorePassword)).get(500, TimeUnit.MILLISECONDS);
             } else {
                 keyStore = createKeyStore(keyStoreType, keyStorePassword);
             }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
@@ -262,7 +262,7 @@ public final class KeyStoreUtils {
         try {
             KeyStore keyStore;
             if (OperatingSystem.get() == WINDOWS) {
-                keyStore = ConcurrentUtils.supplyAsync(() -> createKeyStore(keyStoreType, keyStorePassword)).get(500, TimeUnit.MILLISECONDS);
+                keyStore = ConcurrentUtils.supplyAsync(() -> createKeyStore(keyStoreType, keyStorePassword)).get(1, TimeUnit.SECONDS);
             } else {
                 keyStore = createKeyStore(keyStoreType, keyStorePassword);
             }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/KeyStoreUtils.java
@@ -262,7 +262,7 @@ public final class KeyStoreUtils {
         try {
             KeyStore keyStore;
             if (OperatingSystem.get() == WINDOWS) {
-                keyStore = ConcurrentUtils.supplyAsync(() -> createKeyStore(keyStoreType, keyStorePassword)).get(1, TimeUnit.SECONDS);
+                keyStore = ConcurrentUtils.supplyAsync(() -> createKeyStore(keyStoreType, keyStorePassword)).get(500, TimeUnit.MILLISECONDS);
             } else {
                 keyStore = createKeyStore(keyStoreType, keyStorePassword);
             }
@@ -272,8 +272,8 @@ public final class KeyStoreUtils {
                 LOGGER.debug("Successfully loaded KeyStore of the type [{}] having [{}] entries", keyStoreType, totalTrustedCertificates);
             }
             return Optional.of(keyStore);
-        } catch (Exception ignored) {
-            LOGGER.debug("Failed to load KeyStore of the type [{}]", keyStoreType);
+        } catch (Exception exception) {
+            LOGGER.debug(String.format("Failed to load KeyStore of the type [%s]", keyStoreType), exception);
             return Optional.empty();
         }
     }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/internal/ConcurrencyUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/internal/ConcurrencyUtils.java
@@ -20,11 +20,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
-public final class ConcurrentUtils {
+public final class ConcurrencyUtils {
 
     public static final int NUMBER_OF_THREADS = 1;
 
-    private ConcurrentUtils() {
+    private ConcurrencyUtils() {
     }
 
     public static <T> CompletableFuture<T> supplyAsync(final Supplier<T> supplier) {
@@ -52,8 +52,8 @@ public final class ConcurrentUtils {
         executorService.submit(() -> {
             try {
                 completableFuture.complete(supplier.get());
-            } catch (Throwable throwable) {
-                completableFuture.completeExceptionally(throwable);
+            } catch (Exception exception) {
+                completableFuture.completeExceptionally(exception);
             }
         });
 

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/internal/ConcurrencyUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/internal/ConcurrencyUtils.java
@@ -20,6 +20,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
+/**
+ * <strong>NOTE:</strong>
+ * Please don't use this class directly as it is part of the internal API. Class name and methods can be changed any time.
+ *
+ * @author Hakan Altindag
+ */
 public final class ConcurrencyUtils {
 
     public static final int NUMBER_OF_THREADS = 1;

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/internal/ConcurrencyUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/internal/ConcurrencyUtils.java
@@ -15,6 +15,8 @@
  */
 package nl.altindag.ssl.util.internal;
 
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -33,7 +35,7 @@ public final class ConcurrencyUtils {
     private ConcurrencyUtils() {
     }
 
-    public static <T> CompletableFuture<T> supplyAsync(final Supplier<T> supplier) {
+    public static <T> Map.Entry<CompletableFuture<T>, ExecutorService> supplyAsync(final Supplier<T> supplier) {
         ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
         CompletableFuture<T> completableFuture = new CompletableFuture<T>() {
             @Override
@@ -63,7 +65,7 @@ public final class ConcurrencyUtils {
             }
         });
 
-        return completableFuture;
+        return new SimpleImmutableEntry<>(completableFuture, executorService);
     }
 
 }

--- a/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/internal/ConcurrentUtils.java
+++ b/sslcontext-kickstart/src/main/java/nl/altindag/ssl/util/internal/ConcurrentUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Thunderberry.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.altindag.ssl.util.internal;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+public final class ConcurrentUtils {
+
+    public static final int NUMBER_OF_THREADS = 1;
+
+    private ConcurrentUtils() {
+    }
+
+    public static <T> CompletableFuture<T> supplyAsync(final Supplier<T> supplier) {
+        ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+        CompletableFuture<T> completableFuture = new CompletableFuture<T>() {
+            @Override
+            public boolean complete(T value) {
+                if (isDone()) {
+                    return false;
+                }
+                executorService.shutdownNow();
+                return super.complete(value);
+            }
+
+            @Override
+            public boolean completeExceptionally(Throwable ex) {
+                if (isDone()) {
+                    return false;
+                }
+                executorService.shutdownNow();
+                return super.completeExceptionally(ex);
+            }
+        };
+
+        executorService.submit(() -> {
+            try {
+                completableFuture.complete(supplier.get());
+            } catch (Throwable throwable) {
+                completableFuture.completeExceptionally(throwable);
+            }
+        });
+
+        return completableFuture;
+    }
+
+}

--- a/sslcontext-kickstart/src/test/java/nl/altindag/ssl/util/KeyStoreUtilsShould.java
+++ b/sslcontext-kickstart/src/test/java/nl/altindag/ssl/util/KeyStoreUtilsShould.java
@@ -699,6 +699,7 @@ class KeyStoreUtilsShould {
 
     @Test
     void createKeyStoreIfAvailableReturnsFilledKeyStore() {
+        System.setProperty("os.name", "mac");
         LogCaptor logCaptor = LogCaptor.forClass(KeyStoreUtils.class);
 
         KeyStore bananaKeyStore = mock(KeyStore.class);
@@ -716,6 +717,8 @@ class KeyStoreUtilsShould {
             Optional<KeyStore> keyStore = KeyStoreUtils.createKeyStoreIfAvailable("Banana", null);
             assertThat(keyStore).isPresent();
             assertThat(logCaptor.getDebugLogs()).contains("Successfully loaded KeyStore of the type [Banana] having [2] entries");
+        } finally {
+            resetOsName();
         }
     }
 
@@ -743,6 +746,7 @@ class KeyStoreUtilsShould {
 
     @Test
     void createKeyStoreIfAvailableReturnsFilledKeyStoreWithoutLoggingIfDebugIsDisabled() {
+        System.setProperty("os.name", "mac");
         LogCaptor logCaptor = LogCaptor.forClass(KeyStoreUtils.class);
         logCaptor.setLogLevelToInfo();
 
@@ -761,6 +765,8 @@ class KeyStoreUtilsShould {
             Optional<KeyStore> keyStore = KeyStoreUtils.createKeyStoreIfAvailable("Banana", null);
             assertThat(keyStore).isPresent();
             assertThat(logCaptor.getDebugLogs()).isEmpty();
+        } finally {
+            resetOsName();
         }
     }
 


### PR DESCRIPTION
This PR is an attempt to resolve the issues raised here:
- https://community.sonarsource.com/t/sonarlint-eclipse-hangs-on-sonarlint-core-startup-backend-initialization-after-starting-eclipse/110456
- https://community.sonarsource.com/t/sonarlint-server-rpc-sequential-executor/111277
- https://sonarsource.atlassian.net/browse/SLCORE-669
- https://sonarsource.atlassian.net/browse/SLCORE-686
- https://github.com/SonarSource/sonarlint-core/pull/902